### PR TITLE
(MODULES-9798) Add Timeout Parameter for the Current Puppet Run

### DIFF
--- a/files/install_puppet.ps1
+++ b/files/install_puppet.ps1
@@ -43,7 +43,8 @@ param(
   [AllowEmptyString()]
   [String] $InstallArgs,
   [switch] $UseLockedFilesWorkaround,
-  [Int32] $WaitForPXPAgentExit=120000
+  [Int32] $WaitForPXPAgentExit=120000,
+  [Int32] $WaitForPuppetRun=120000
 )
 
 # $PSScript is only available in Powershell >= 3.
@@ -273,7 +274,7 @@ try {
     Write-Log "Waiting for puppet to stop, PID:$PuppetPID" $Logfile
     $pup_process = Get-Process -ID $PuppetPID -ErrorAction SilentlyContinue
     if ($pup_process) {
-      if (!$pup_process.WaitForExit(120000)){
+      if (!$pup_process.WaitForExit($WaitForPuppetRun)){
         Write-Log "ERROR: Timed out waiting for puppet!" $Logfile
         throw
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -114,6 +114,7 @@ class puppet_agent (
   $skip_if_unavailable     = 'absent',
   $msi_move_locked_files   = false,
   $wait_for_pxp_agent_exit = undef,
+  $wait_for_puppet_run     = undef,
 ) inherits ::puppet_agent::params {
 
   if (getvar('::aio_agent_version') == undef) {

--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -43,6 +43,12 @@ class puppet_agent::install::windows(
     $_pxp_agent_wait = undef
   }
 
+  if $::puppet_agent::wait_for_puppet_run {
+    $_puppet_run_wait = "-WaitForPuppetRun ${puppet_agent::wait_for_puppet_run}"
+  } else {
+    $_puppet_run_wait = undef
+  }
+
   $_timestamp = strftime('%Y_%m_%d-%H_%M')
   $_logfile = windows_native_path("${::env_temp_variable}/puppet-${_timestamp}-installer.log")
 
@@ -95,7 +101,8 @@ class puppet_agent::install::windows(
                           -PuppetStartType '${_agent_startup_mode}' \
                           -InstallArgs '${_install_options}' \
                           ${_move_dll_workaround} \
-                          ${_pxp_agent_wait}",
+                          ${_pxp_agent_wait} \
+                          ${_puppet_run_wait}",
     unless  => "${::system32}\\WindowsPowerShell\\v1.0\\powershell.exe \
                   -ExecutionPolicy Bypass \
                   -NoProfile \

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-puppet_agent",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "author": "puppetlabs",
   "summary": "Upgrades All-In-One Puppet Agents",
   "license": "Apache-2.0",

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -287,6 +287,34 @@ RSpec.describe 'puppet_agent', tag: 'win' do
           }
         end
       end
+
+      context 'wait_for_puppet_run =>' do
+        describe 'default' do
+          it {
+            is_expected.not_to contain_exec('install_puppet.ps1').with_command(/\-WaitForPuppetRun/)
+          }
+        end
+
+        describe 'specify false' do
+          let(:params) { global_params.merge(
+            {:wait_for_puppet_run => false,})
+          }
+
+          it {
+            is_expected.not_to contain_exec('install_puppet.ps1').with_command(/\-WaitForPuppetRun/)
+          }
+        end
+
+        describe 'specify true' do
+          let(:params) { global_params.merge(
+            {:wait_for_puppet_run => true,})
+          }
+
+          it {
+            is_expected.to contain_exec('install_puppet.ps1').with_command(/\-WaitForPuppetRun/)
+          }
+        end
+      end
     end
   
     context 'rubyplatform' do


### PR DESCRIPTION
(Support-42796) Add wait_for_puppet_run parameter to configure the
timeout value for the current puppet run.
Previously, if the puppet agent was to be upgraded but the current run
took longer than 120000 ms (2 minutes) to complete, the agent upgrade
script (install_puppet.ps1) would fail. This would happen even if the
agent run would have otherwise completed without error.
Fixed wait_for_pxp_agent_exit parameter tests. The parameter accepts an
Int32, but the tests were passing booleans.